### PR TITLE
Datadev

### DIFF
--- a/typescriptSample/src/data/reviews.ts
+++ b/typescriptSample/src/data/reviews.ts
@@ -53,9 +53,9 @@ async function create(review: Review): Promise<Review<string>> {
   if (!newInsertInformation.insertedId || !newInsertInformation.acknowledged)
   	throw `Error: Review insertion failed!`;
   let foundReview = await getById(newInsertInformation.insertedId.toString()) as Review<string>;
-  users.addReviewByUserId(foundReview);
+  await users.addReviewByUserId(foundReview);
 
-  return await getById(newInsertInformation.insertedId.toString());
+  return getById(newInsertInformation.insertedId.toString());
 }
 
 export = {

--- a/typescriptSample/src/data/users.ts
+++ b/typescriptSample/src/data/users.ts
@@ -87,15 +87,20 @@ async function checkUser(user: User): Promise<User<string>> {
  * Adds the _id of the given Review to its associated User with id posterId
  *
  * @param {Review} review - User to check
- * @return {Promise<User<string>>}- A promise for the updated User
+ * @return {Promise<User<string>>}- A promise for the updated customer
  */
 async function addReviewByUserId(review: Review<string | ObjectId>): Promise<User<string>> {
 	const userCollection = await users();
-	const updatedInformation = await userCollection.updateOne(
+	const updatedInformationCustomer = await userCollection.updateOne(
 		{_id: new ObjectId(review.posterId)},
 		{$push: {reviewIds: review._id!} });
-	if (updatedInformation.modifiedCount === 0 || !updatedInformation.acknowledged) 
-		throw `Error: Review addition to user failed`;
+	const updatedInformationHairdresser= await userCollection.updateOne(
+		{_id: new ObjectId(review.posterId)},
+		{$push: {reviewIds: review._id!} });		
+	if (updatedInformationCustomer.modifiedCount === 0 || !updatedInformationCustomer.acknowledged) 
+		throw `Error: Review addition to customer failed`;
+	if (updatedInformationHairdresser.modifiedCount === 0 || !updatedInformationHairdresser.acknowledged) 
+		throw `Error: Review addition to customer failed`;
 	return await getById(review.posterId);
 }
 /**

--- a/typescriptSample/src/routes/reviews.ts
+++ b/typescriptSample/src/routes/reviews.ts
@@ -20,6 +20,7 @@ router.post('/', async (req, res) => {
     console.log(b.posterId, b.hairdresserId, b.body, b.rating);
     const revw = utils.validateReview(
       b.posterId,
+	  b.hairdresserId,
       b.appointmentId,
       b.body,
       b.rating

--- a/typescriptSample/src/tasks/seed.ts
+++ b/typescriptSample/src/tasks/seed.ts
@@ -74,6 +74,7 @@ async function main() {
 
   const review1 = await reviews.create({
     posterId: usr._id!.toString(),
+	hairdresserId: hrdsr._id!.toString(),
     appointmentId: appt1._id!.toString(),
     body: 'First review',
     rating: 4.6,
@@ -81,6 +82,7 @@ async function main() {
 
   const review2 = await reviews.create({
     posterId: usr._id!.toString(),
+	hairdresserId: hrdsr._id!.toString(),
     appointmentId: appt2._id!.toString(),
     body: 'Second review',
     rating: 1.3,
@@ -88,6 +90,7 @@ async function main() {
 
   const review3 = await reviews.create({
     posterId: usr._id!.toString(),
+	hairdresserId: hrdsr._id!.toString(),
     appointmentId: appt3._id!.toString(),
     body: 'third review',
     rating: 4.8,

--- a/typescriptSample/src/tasks/seed.ts
+++ b/typescriptSample/src/tasks/seed.ts
@@ -40,23 +40,57 @@ async function main() {
 
   console.log('Done seeding users in database');
 
-  const appt = await appointments.create({
+  const appt1 = await appointments.create({
     customerId: usr._id!.toString(),
     hairdresserId: hrdsr._id!.toString(),
     startTime: new Date('2022-03-12 12:00 EST').getTime(),
     endTime: new Date('2022-03-12 13:00 EST').getTime(),
     service: 'haircut',
-    comments: '',
+    comments: 'First appointment',
     price: 12.99,
+  });
+
+  const appt2 = await appointments.create({
+    customerId: usr._id!.toString(),
+    hairdresserId: hrdsr._id!.toString(),
+    startTime: new Date('2022-03-12 13:00 EST').getTime(),
+    endTime: new Date('2022-03-12 14:00 EST').getTime(),
+    service: 'haircut',
+    comments: 'Second appointment',
+    price: 14.99,
+  });
+
+  const appt3 = await appointments.create({
+    customerId: usr._id!.toString(),
+    hairdresserId: hrdsr._id!.toString(),
+    startTime: new Date('2022-03-12 14:00 EST').getTime(),
+    endTime: new Date('2022-03-12 15:00 EST').getTime(),
+    service: 'haircut',
+    comments: 'Third appointment',
+    price: 14.99,
   });
 
   console.log('Done seeding appointments in database');
 
-  const review = await reviews.create({
+  const review1 = await reviews.create({
     posterId: usr._id!.toString(),
-    appointmentId: appt._id!.toString(),
-    body: 'The service was excellent!',
+    appointmentId: appt1._id!.toString(),
+    body: 'First review',
     rating: 4.6,
+  });
+
+  const review2 = await reviews.create({
+    posterId: usr._id!.toString(),
+    appointmentId: appt2._id!.toString(),
+    body: 'Second review',
+    rating: 1.3,
+  });
+
+  const review3 = await reviews.create({
+    posterId: usr._id!.toString(),
+    appointmentId: appt3._id!.toString(),
+    body: 'third review',
+    rating: 4.8,
   });
 
   console.log('Done seeding reviews in database');

--- a/typescriptSample/src/utils/types.ts
+++ b/typescriptSample/src/utils/types.ts
@@ -16,6 +16,7 @@ export interface Appointment<T = undefined> extends Schema<T> {
 export interface Review<T = undefined> extends Schema<T> {
   _id?: T;
   posterId: string;
+  hairdresserId: string;
   appointmentId: string;
   body: string;
   rating: number;

--- a/typescriptSample/src/utils/validation.ts
+++ b/typescriptSample/src/utils/validation.ts
@@ -56,17 +56,20 @@ export function validateAppointment(
  */
 export function validateReview(
   posterId: string,
+  hairdresserId: string,
   appointmentId: string,
   body: string,
   rating: number
 ): Review {
   const pid = utils.checkId(posterId, 'poster');
+  const hid = utils.checkId(hairdresserId, 'hairdresser');
   const aid = utils.checkId(appointmentId, 'appointment');
   const bdy = utils.checkString(body, 'body');
   const rtg = utils.checkNumber(rating, 1, 5, 'rating');
 
   const revw: Review = {
     posterId: pid,
+	hairdresserId: hid,
     appointmentId: aid,
     body: bdy,
     rating: rtg,


### PR DESCRIPTION
Reviews now have the hairdresserId field in addition to the appointmentId field, to make querying by different id types much easier

More appointments/reviews in seed

Hairdresser ("admin") users now also have their associated reviewIds, just like the customers who created them.

Some minor fixes to how  data/users.addReviewByUserId was called, which was missing an await()